### PR TITLE
Lattice 1910 dont create indexes for binary datatypes

### DIFF
--- a/src/main/java/com/openlattice/ApiUtil.java
+++ b/src/main/java/com/openlattice/ApiUtil.java
@@ -18,24 +18,18 @@
 
 package com.openlattice;
 
-import java.nio.ByteBuffer;
-import java.util.Base64;
-import java.util.Base64.Encoder;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.dataloom.mappers.ObjectMappers;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.SetMultimap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.Base64.Encoder;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ApiUtil {
     private static final Encoder encoder = Base64.getEncoder();
@@ -53,7 +47,7 @@ public class ApiUtil {
 
     public static String generateDefaultEntityId( Stream<UUID> keys, Map<UUID, Set<Object>> entityDetails ) {
         String entityId = keys.map( entityDetails::get )
-                .filter( obj -> obj != null )
+                .filter( Objects::nonNull )
                 .map( ApiUtil::joinObjectsAsString )
                 .map( ApiUtil::toUtf8Bytes )
                 .map( encoder::encodeToString )

--- a/src/main/java/com/openlattice/edm/requests/MetadataUpdate.java
+++ b/src/main/java/com/openlattice/edm/requests/MetadataUpdate.java
@@ -18,21 +18,19 @@
 
 package com.openlattice.edm.requests;
 
-import com.google.common.collect.LinkedHashMultimap;
-import com.openlattice.authorization.Principal;
-import com.openlattice.client.serialization.SerializationConstants;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-
+import com.google.common.collect.LinkedHashMultimap;
+import com.openlattice.client.serialization.SerializationConstants;
+import com.openlattice.postgres.IndexType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.olingo.commons.api.edm.FullQualifiedName;
 
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Used for updating metadata of property type, entity type, or entity set. Non-existent fields for the specific object
@@ -43,6 +41,7 @@ public class MetadataUpdate {
     // Common across property type, entity type, entity set
     private Optional<String>                           title;
     private Optional<String>                           description;
+    private Optional<IndexType>                        indexType;
     // Specific to entity set
     private Optional<String>                           name;
     private Optional<Set<String>>                      contacts;
@@ -68,6 +67,7 @@ public class MetadataUpdate {
             @JsonProperty( SerializationConstants.URL ) Optional<String> url,
             @JsonProperty( SerializationConstants.PROPERTY_TAGS )
                     Optional<LinkedHashMultimap<UUID, String>> propertyTags,
+            @JsonProperty( SerializationConstants.INDEX_TYPE ) Optional<IndexType> indexType,
             @JsonProperty( SerializationConstants.ORGANIZATION_ID ) Optional<UUID> organizationId ) {
         // WARNING These checks have to be consistent with the same check elsewhere.
         Preconditions.checkArgument( !title.isPresent() || StringUtils.isNotBlank( title.get() ),
@@ -89,7 +89,22 @@ public class MetadataUpdate {
         this.defaultShow = defaultShow;
         this.url = url;
         this.propertyTags = propertyTags;
+        this.indexType = indexType;
         this.organizationId = organizationId;
+    }
+
+    public MetadataUpdate(
+             Optional<String> title,
+             Optional<String> description,
+             Optional<String> name,
+             Optional<Set<String>> contacts,
+             Optional<FullQualifiedName> type,
+             Optional<Boolean> pii,
+             Optional<Boolean> defaultShow,
+             Optional<String> url,
+             Optional<LinkedHashMultimap<UUID, String>> propertyTags,
+             Optional<UUID> organizationId ) {
+        this(title, description, name, contacts, type, pii, defaultShow, url, propertyTags, Optional.empty(), organizationId);
     }
 
     @JsonProperty( SerializationConstants.TITLE_FIELD )
@@ -153,6 +168,7 @@ public class MetadataUpdate {
                 ", defaultShow=" + defaultShow +
                 ", url=" + url +
                 ", propertyTags=" + propertyTags +
+                ", indexType=" + indexType +
                 ", organization=" + organizationId +
                 '}';
     }
@@ -170,12 +186,13 @@ public class MetadataUpdate {
                 Objects.equals( defaultShow, that.defaultShow ) &&
                 Objects.equals( url, that.url ) &&
                 Objects.equals( propertyTags, that.propertyTags ) &&
+                Objects.equals( indexType, that.indexType ) &&
                 Objects.equals( organizationId, that.organizationId );
     }
 
     @Override public int hashCode() {
         return Objects
-                .hash( title, description, name, contacts, type, pii, defaultShow, url, propertyTags, organizationId );
+                .hash( title, description, name, contacts, type, pii, defaultShow, url, propertyTags, indexType, organizationId );
     }
 
     //TODO: Delete the code below as it doesn't seem to be used.

--- a/src/main/java/com/openlattice/edm/requests/MetadataUpdate.java
+++ b/src/main/java/com/openlattice/edm/requests/MetadataUpdate.java
@@ -157,6 +157,11 @@ public class MetadataUpdate {
         return organizationId;
     }
 
+    @JsonProperty( SerializationConstants.INDEX_TYPE)
+    public Optional<IndexType> getIndexType() {
+        return indexType;
+    }
+
     @Override public String toString() {
         return "MetadataUpdate{" +
                 "title=" + title +

--- a/src/main/java/com/openlattice/edm/type/PropertyType.java
+++ b/src/main/java/com/openlattice/edm/type/PropertyType.java
@@ -18,8 +18,6 @@
 
 package com.openlattice.edm.type;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -29,17 +27,13 @@ import com.google.common.base.Preconditions;
 import com.openlattice.authorization.securable.AbstractSchemaAssociatedSecurableType;
 import com.openlattice.authorization.securable.SecurableObjectType;
 import com.openlattice.client.serialization.SerializationConstants;
-
-import java.util.EnumSet;
-import java.util.LinkedHashSet;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-
 import com.openlattice.postgres.IndexType;
 import org.apache.olingo.commons.api.edm.EdmPrimitiveTypeKind;
 import org.apache.olingo.commons.api.edm.FullQualifiedName;
+
+import java.util.*;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
@@ -89,7 +83,11 @@ public class PropertyType extends AbstractSchemaAssociatedSecurableType {
         this.piiField = piiField.orElse( false );
         this.multiValued = multiValued.orElse( true );
         this.analyzer = analyzer.orElse( Analyzer.STANDARD );
-        this.postgresIndexType = postgresIndexType.orElse( IndexType.BTREE );
+        if ( EdmPrimitiveTypeKind.Binary == this.datatype ) {
+            this.postgresIndexType = IndexType.NONE;
+        } else {
+            this.postgresIndexType = postgresIndexType.orElse( IndexType.BTREE );
+        }
     }
 
     public PropertyType(

--- a/src/main/java/com/openlattice/edm/type/PropertyType.java
+++ b/src/main/java/com/openlattice/edm/type/PropertyType.java
@@ -209,6 +209,11 @@ public class PropertyType extends AbstractSchemaAssociatedSecurableType {
         return enumValues;
     }
 
+    @JsonIgnore
+    public void setPostgresIndexType( IndexType postgresIndexType ) {
+        this.postgresIndexType = postgresIndexType;
+    }
+
     @Override public boolean equals( Object o ) {
         if ( this == o ) { return true; }
         if ( !( o instanceof PropertyType ) ) { return false; }

--- a/src/main/java/com/openlattice/edm/type/PropertyType.java
+++ b/src/main/java/com/openlattice/edm/type/PropertyType.java
@@ -83,11 +83,11 @@ public class PropertyType extends AbstractSchemaAssociatedSecurableType {
         this.piiField = piiField.orElse( false );
         this.multiValued = multiValued.orElse( true );
         this.analyzer = analyzer.orElse( Analyzer.STANDARD );
+
         if ( EdmPrimitiveTypeKind.Binary == this.datatype ) {
-            this.postgresIndexType = IndexType.NONE;
-        } else {
-            this.postgresIndexType = postgresIndexType.orElse( IndexType.BTREE );
+            checkArgument( this.postgresIndexType == IndexType.NONE, "Indexes are not allowed on Binary datatypes" );
         }
+        this.postgresIndexType = postgresIndexType.orElse( IndexType.BTREE );
     }
 
     public PropertyType(

--- a/src/main/java/com/openlattice/edm/type/PropertyType.java
+++ b/src/main/java/com/openlattice/edm/type/PropertyType.java
@@ -84,8 +84,8 @@ public class PropertyType extends AbstractSchemaAssociatedSecurableType {
         this.multiValued = multiValued.orElse( true );
         this.analyzer = analyzer.orElse( Analyzer.STANDARD );
 
-        if ( EdmPrimitiveTypeKind.Binary == this.datatype ) {
-            checkArgument( this.postgresIndexType == IndexType.NONE, "Indexes are not allowed on Binary datatypes" );
+        if ( EdmPrimitiveTypeKind.Binary == this.datatype && postgresIndexType.isPresent() ) {
+            checkArgument( postgresIndexType.get() == IndexType.NONE, "Indexes are not allowed on Binary datatypes" );
         }
         this.postgresIndexType = postgresIndexType.orElse( IndexType.BTREE );
     }


### PR DESCRIPTION
This PR: 
- Forces Binary data to not be indexed in the PropertyType constructor
- Adds IndexType to MetadataUpdate
- Adds setters and getters for IndexType in various classes
- fixes a warning