### PR TITLE
Bump swagger version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.openapitools:openapi-generator-gradle-plugin:3.3.4"
+        classpath "org.openapitools:openapi-generator-gradle-plugin:4.0.1"
     }
 
     configurations.classpath {
@@ -23,7 +23,7 @@ plugins {
     id 'com.github.spotbugs' version '2.0.0'
     id 'org.jetbrains.kotlin.jvm' version '1.3.31'
     id 'org.jetbrains.kotlin.plugin.spring' version '1.3.31'
-    id 'org.hidetake.swagger.generator' version '2.16.0'
+    id 'org.hidetake.swagger.generator' version '2.18.1'
 }
 
 description = "OpenLattice REST APIs"
@@ -98,6 +98,7 @@ task generateConfluenceDocs(type: org.openapitools.generator.gradle.plugin.tasks
     generatorName = "cwiki"
     inputSpec = file("openlattice.yaml").getAbsolutePath()
     outputDir = file("build/openapi/cwiki").getAbsolutePath()
+    validateSpec = false
 }
 
 task generatePythonClient(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
@@ -105,6 +106,7 @@ task generatePythonClient(type: org.openapitools.generator.gradle.plugin.tasks.G
     inputSpec = file("openlattice.yaml").getAbsolutePath()
     outputDir = file("build/openapi/python").getAbsolutePath()
     configFile = file("oas-config.json").getAbsolutePath()
+    validateSpec = false
 }
 
 task generateRClient(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
@@ -112,6 +114,7 @@ task generateRClient(type: org.openapitools.generator.gradle.plugin.tasks.Genera
     inputSpec = file("openlattice.yaml").getAbsolutePath()
     outputDir = file("build/openapi/r").getAbsolutePath()
     configFile = file("oas-config.json").getAbsolutePath()
+    validateSpec = false
 }
 
 task generateKotlinClient(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
@@ -124,6 +127,7 @@ task generateKotlinClient(type: org.openapitools.generator.gradle.plugin.tasks.G
     configOptions = [
             dateLibrary: "java8"
     ]
+    validateSpec = false
 }
 
 clean.doFirst {
@@ -138,8 +142,8 @@ dependencies {
     testCompileOnly 'net.jcip:jcip-annotations:1.0'
     testCompileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.12'
 
-    swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.4'
-    swaggerUI 'org.webjars:swagger-ui:3.20.5'
+    swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.8'
+    swaggerUI 'org.webjars:swagger-ui:3.22.2'
 
     /*
      * SL4J


### PR DESCRIPTION
This breaks swagger codegen as whatever method of doing refs we were using before is no longer liked by latest version of code generator.