### PR TITLE
add EMPTY_UUID for default ORIGIN_ID

### DIFF
--- a/src/main/kotlin/com/openlattice/IdConstants.kt
+++ b/src/main/kotlin/com/openlattice/IdConstants.kt
@@ -57,15 +57,15 @@ enum class IdConstants(val id: UUID) {
     CONTACT_INFO_ENTITY_SET_ID(UUID(8L, 20L)),
     LINKING_PERSON_ENTITY_SET_ID(UUID(9L, 20L)),
 
-    // empty origin ID
-    EMPTY_UUID(UUID(0L, 0L)),
-
     /* Linker */
 
     /**
      * Entity sets ids are assigned by calling [UUID.randomUUID] as a result we know that this can never be accidentally
      * assigned to any real entity set.
      */
-    LINKING_ENTITY_SET_ID(UUID(0L, 40L))
+    LINKING_ENTITY_SET_ID(UUID(0L, 40L)),
+
+    // empty origin ID
+    EMPTY_ORIGIN_ID(UUID(1L, 40L)),
 
 }

--- a/src/main/kotlin/com/openlattice/IdConstants.kt
+++ b/src/main/kotlin/com/openlattice/IdConstants.kt
@@ -21,43 +21,44 @@
 
 package com.openlattice
 
-import java.util.UUID
+import java.util.*
 
 enum class IdConstants(val id: UUID) {
 
 
     /* Organizations */
 
-    OPENLATTICE_ORGANIZATION_ID(UUID(0, 0)),
-    GLOBAL_ORGANIZATION_ID(UUID(1, 0)),
-    ROOT_PRINCIPAL_ID(UUID(0, 1)),
+    OPENLATTICE_ORGANIZATION_ID(UUID(0L, 0L)),
+    GLOBAL_ORGANIZATION_ID(UUID(1L, 0L)),
+    ROOT_PRINCIPAL_ID(UUID(0L, 1L)),
 
 
     /* ElasticSearch */
 
-    ENTITY_SET_ID_KEY_ID(UUID(0, 10)), // was UUID(0, 1)
-    LAST_WRITE_KEY_ID(UUID(1, 10)), // was UUID(0, 0)
+    ENTITY_SET_ID_KEY_ID(UUID(0L, 10L)), // was UUID(0, 1)
+    LAST_WRITE_KEY_ID(UUID(1L, 10L)), // was UUID(0, 0)
 
 
     /* Postgres */
 
     // misc
-    COUNT_ID(UUID(0, 20)),
-    ID_ID(UUID(1, 20)),
+    COUNT_ID(UUID(0L, 20L)),
+    ID_ID(UUID(1L, 20L)),
 
     // metadata
-    ENTITY_KEY_IDS_ID(UUID(2, 20)),
-    ENTITY_SET_IDS_ID(UUID(3, 20)),
-    LAST_INDEX_ID(UUID(4, 20)),
-    LAST_LINK_ID(UUID(5, 20)),
-    LAST_WRITE_ID(UUID(6, 20)),
-    VERSION_ID(UUID(7, 20)),
+    ENTITY_KEY_IDS_ID(UUID(2L, 20L)),
+    ENTITY_SET_IDS_ID(UUID(3L, 20L)),
+    LAST_INDEX_ID(UUID(4L, 20L)),
+    LAST_LINK_ID(UUID(5L, 20L)),
+    LAST_WRITE_ID(UUID(6L, 20L)),
+    VERSION_ID(UUID(7L, 20L)),
 
     // entity set ids
-    CONTACT_INFO_ENTITY_SET_ID(UUID(8, 20)),
-    LINKING_PERSON_ENTITY_SET_ID(UUID(9, 20)),
+    CONTACT_INFO_ENTITY_SET_ID(UUID(8L, 20L)),
+    LINKING_PERSON_ENTITY_SET_ID(UUID(9L, 20L)),
 
-
+    // empty origin ID
+    EMPTY_UUID(UUID(0L, 0L)),
 
     /* Linker */
 
@@ -65,6 +66,6 @@ enum class IdConstants(val id: UUID) {
      * Entity sets ids are assigned by calling [UUID.randomUUID] as a result we know that this can never be accidentally
      * assigned to any real entity set.
      */
-    LINKING_ENTITY_SET_ID(UUID(0, 40))
+    LINKING_ENTITY_SET_ID(UUID(0L, 40L))
 
 }

--- a/src/main/kotlin/com/openlattice/IdConstants.kt
+++ b/src/main/kotlin/com/openlattice/IdConstants.kt
@@ -21,7 +21,7 @@
 
 package com.openlattice
 
-import java.util.*
+import java.util.UUID
 
 enum class IdConstants(val id: UUID) {
 

--- a/src/main/kotlin/com/openlattice/linking/EntityLinkingFeedback.kt
+++ b/src/main/kotlin/com/openlattice/linking/EntityLinkingFeedback.kt
@@ -31,4 +31,6 @@ import com.openlattice.data.EntityDataKey
 data class EntityLinkingFeedback(
         @JsonProperty(SerializationConstants.ENTITY_KEY_IDS) val entityPair: EntityKeyPair,
         @JsonProperty(SerializationConstants.LINKED) val linked: Boolean
-)
+) {
+    constructor( ent: Map.Entry<EntityKeyPair, Boolean> ) : this( ent.key, ent.value )
+}


### PR DESCRIPTION
This PR:
- Updates IdConstants with an EMPTY_UUID value
- Changes all arguments to these UUIDs to be Longs instead of Ints