### PR TITLE
bugfix entitysets property metadata: not a map

### DIFF
--- a/openlattice.yaml
+++ b/openlattice.yaml
@@ -2855,11 +2855,9 @@ components:
         description:
           type: string
         propertyTags:
-          type: object
-          additionalProperties:
-            type: array
-            items:
-              type: string
+          type: array
+          items:
+            type: string
         defaultShow:
           type: boolean
 


### PR DESCRIPTION
just a list