### PR TITLE
Fix/warnings

### DIFF
--- a/src/main/java/com/openlattice/analysis/requests/WeightedRankingAggregation.java
+++ b/src/main/java/com/openlattice/analysis/requests/WeightedRankingAggregation.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.openlattice.client.serialization.SerializationConstants;
 import java.util.Objects;
-import java.util.UUID;
 
 /**
  * Model for specifying weight ranking aggregation.

--- a/src/main/java/com/openlattice/authorization/AclExplanation.java
+++ b/src/main/java/com/openlattice/authorization/AclExplanation.java
@@ -20,7 +20,6 @@ package com.openlattice.authorization;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 
 import com.openlattice.client.serialization.SerializationConstants;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/openlattice/authorization/Principal.java
+++ b/src/main/java/com/openlattice/authorization/Principal.java
@@ -19,7 +19,6 @@
 package com.openlattice.authorization;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 
 import com.openlattice.client.serialization.SerializationConstants;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/openlattice/authorization/SystemRole.java
+++ b/src/main/java/com/openlattice/authorization/SystemRole.java
@@ -55,6 +55,6 @@ public enum SystemRole {
     }
     
     public static String[] valuesAsArray() {
-        return allRoles.toArray( new String[ allRoles.size() ] );
+        return allRoles.toArray( new String[ 0 ] );
     }
 };

--- a/src/main/java/com/openlattice/authorization/SystemRole.java
+++ b/src/main/java/com/openlattice/authorization/SystemRole.java
@@ -35,7 +35,7 @@ public enum SystemRole {
     private static final Set<String> allRoles;
 
     static {
-        allRoles = Stream.of( values() ).map( role -> role.getName() ).collect( Collectors.toSet() );
+        allRoles = Stream.of( values() ).map( SystemRole::getName ).collect( Collectors.toSet() );
     }
 
     private SystemRole( String principalId ) {

--- a/src/main/java/com/openlattice/client/ApiClient.java
+++ b/src/main/java/com/openlattice/client/ApiClient.java
@@ -62,7 +62,7 @@ public class ApiClient implements ApiFactoryFactory {
     public ApiClient( SerializableSupplier<String> jwtToken ) {
         this( () -> {
             final Retrofit retrofit = RetrofitFactory.newClient( jwtToken );
-            return (ApiFactory) clazz -> retrofit.create( clazz );
+            return (ApiFactory) retrofit::create;
         } );
     }
 

--- a/src/main/java/com/openlattice/client/ApiClient.java
+++ b/src/main/java/com/openlattice/client/ApiClient.java
@@ -120,7 +120,7 @@ public class ApiClient implements ApiFactoryFactory {
             apiCache = CacheBuilder.newBuilder()
                     .maximumSize( 100 )
                     .initialCapacity( 10 )
-                    .build( new CacheLoader<Class<?>, Object>() {
+                    .build( new CacheLoader<>() {
                         private final Supplier<ApiFactory> apiFactory = Suppliers.memoize( retrofitSupplier::get );
 
                         @Override

--- a/src/main/java/com/openlattice/client/ApiClient.java
+++ b/src/main/java/com/openlattice/client/ApiClient.java
@@ -18,7 +18,6 @@
 
 package com.openlattice.client;
 
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -41,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import retrofit2.Retrofit;
 
 import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
 
 public class ApiClient implements ApiFactoryFactory {
 
@@ -121,7 +121,7 @@ public class ApiClient implements ApiFactoryFactory {
                     .maximumSize( 100 )
                     .initialCapacity( 10 )
                     .build( new CacheLoader<>() {
-                        private final Supplier<ApiFactory> apiFactory = Suppliers.memoize( retrofitSupplier::get );
+                        private final Supplier<ApiFactory> apiFactory = Suppliers.memoize( retrofitSupplier::get )::get;
 
                         @Override
                         public Object load( Class<?> key ) throws Exception {

--- a/src/main/java/com/openlattice/data/DataAssociation.java
+++ b/src/main/java/com/openlattice/data/DataAssociation.java
@@ -22,11 +22,9 @@
 package com.openlattice.data;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.SetMultimap;
 import com.openlattice.client.serialization.SerializationConstants;
 
 import java.util.Map;

--- a/src/main/java/com/openlattice/data/DataEdge.java
+++ b/src/main/java/com/openlattice/data/DataEdge.java
@@ -23,10 +23,8 @@ package com.openlattice.data;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.SetMultimap;
 import com.openlattice.client.serialization.SerializationConstants;
 
-import java.io.Serializable;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;

--- a/src/main/java/com/openlattice/data/EntityKey.java
+++ b/src/main/java/com/openlattice/data/EntityKey.java
@@ -64,7 +64,6 @@ public class EntityKey implements Comparable<EntityKey> {
     }
 
     @Override public int hashCode() {
-
         return Objects.hash( entitySetId, entityId );
     }
 

--- a/src/main/java/com/openlattice/data/requests/LookupEntitiesRequest.java
+++ b/src/main/java/com/openlattice/data/requests/LookupEntitiesRequest.java
@@ -66,7 +66,7 @@ public class LookupEntitiesRequest {
     			.stream()
     			.collect(Collectors.toMap(
     						entry -> new FullQualifiedName( entry.getKey() ),
-    						entry -> entry.getValue()
+                        Map.Entry::getValue
     					)
     			);
     	

--- a/src/main/java/com/openlattice/data/requests/NeighborEntityDetails.java
+++ b/src/main/java/com/openlattice/data/requests/NeighborEntityDetails.java
@@ -20,13 +20,14 @@ package com.openlattice.data.requests;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
 import com.openlattice.client.serialization.SerializationConstants;
 import com.openlattice.edm.EntitySet;
+import org.apache.olingo.commons.api.edm.FullQualifiedName;
+
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import org.apache.olingo.commons.api.edm.FullQualifiedName;
 
 public class NeighborEntityDetails {
     private final EntitySet                              associationEntitySet;
@@ -79,9 +80,9 @@ public class NeighborEntityDetails {
         this(
                 associationEntitySet,
                 associationDetails,
-                Optional.absent(),
-                Optional.absent(),
-                Optional.absent(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 entityIsSrc );
     }
 

--- a/src/main/java/com/openlattice/edm/EdmApi.java
+++ b/src/main/java/com/openlattice/edm/EdmApi.java
@@ -23,7 +23,6 @@ import com.openlattice.data.requests.FileType;
 import com.openlattice.edm.requests.EdmDetailsSelector;
 import com.openlattice.edm.requests.EdmRequest;
 import com.openlattice.edm.requests.MetadataUpdate;
-import com.openlattice.edm.set.EntitySetPropertyMetadata;
 import com.openlattice.edm.type.*;
 import org.apache.olingo.commons.api.edm.FullQualifiedName;
 import retrofit2.http.*;

--- a/src/main/java/com/openlattice/edm/EntitySet.java
+++ b/src/main/java/com/openlattice/edm/EntitySet.java
@@ -18,9 +18,6 @@
 
 package com.openlattice.edm;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -31,6 +28,7 @@ import com.openlattice.authorization.securable.SecurableObjectType;
 import com.openlattice.client.serialization.SerializationConstants;
 import com.openlattice.data.DataExpiration;
 import com.openlattice.edm.set.EntitySetFlag;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collection;
 import java.util.EnumSet;
@@ -41,9 +39,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.commons.lang3.StringUtils;
-
-import javax.swing.*;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Describes an entity set and associated metadata, including the active audit record entity set.

--- a/src/main/java/com/openlattice/edm/requests/MetadataUpdate.java
+++ b/src/main/java/com/openlattice/edm/requests/MetadataUpdate.java
@@ -35,8 +35,6 @@ import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.olingo.commons.api.edm.FullQualifiedName;
 
-import javax.xml.crypto.Data;
-
 /**
  * Used for updating metadata of property type, entity type, or entity set. Non-existent fields for the specific object
  * would be ignored.

--- a/src/main/java/com/openlattice/edm/type/LinkingEntityType.java
+++ b/src/main/java/com/openlattice/edm/type/LinkingEntityType.java
@@ -18,11 +18,11 @@
 
 package com.openlattice.edm.type;
 
-import com.openlattice.client.serialization.SerializationConstants;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
+import com.openlattice.client.serialization.SerializationConstants;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -42,7 +42,7 @@ public class LinkingEntityType {
             @JsonProperty( SerializationConstants.DEIDENTIFIED ) Optional<Boolean> deidentified ) {
         this.linkingEntityType = linkingEntityType;
         this.linkedEntityTypes = linkedEntityTypes;
-        this.deidentified = deidentified.or( true );
+        this.deidentified = deidentified.orElse( true );
     }
 
     @JsonProperty( SerializationConstants.ENTITY_TYPE )

--- a/src/main/java/com/openlattice/graph/query/AbstractBooleanClauses.java
+++ b/src/main/java/com/openlattice/graph/query/AbstractBooleanClauses.java
@@ -22,7 +22,6 @@
 package com.openlattice.graph.query;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/openlattice/graph/query/BooleanClauses.java
+++ b/src/main/java/com/openlattice/graph/query/BooleanClauses.java
@@ -25,7 +25,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.Arrays.asList;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.openlattice.graph.BooleanClauseVisitor;
 import com.openlattice.graph.query.AbstractBooleanClauses.And;
 import com.openlattice.graph.query.AbstractBooleanClauses.Or;
 import java.util.HashSet;

--- a/src/main/java/com/openlattice/graph/query/EntityQuery.java
+++ b/src/main/java/com/openlattice/graph/query/EntityQuery.java
@@ -25,7 +25,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.Arrays.asList;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.openlattice.graph.EntityQueryVisitor;
 import com.openlattice.graph.query.AbstractEntityQuery.And;
 import com.openlattice.graph.query.AbstractEntityQuery.Or;
 import java.util.HashSet;

--- a/src/main/java/com/openlattice/graph/query/Query.java
+++ b/src/main/java/com/openlattice/graph/query/Query.java
@@ -21,14 +21,7 @@
 
 package com.openlattice.graph.query;
 
-import static java.util.Arrays.asList;
-
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;

--- a/src/main/java/com/openlattice/linking/RealtimeLinkingApi.java
+++ b/src/main/java/com/openlattice/linking/RealtimeLinkingApi.java
@@ -23,7 +23,6 @@ package com.openlattice.linking;
 import retrofit2.http.GET;
 import retrofit2.http.Path;
 
-import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 

--- a/src/main/java/com/openlattice/mapstores/TestDataFactory.java
+++ b/src/main/java/com/openlattice/mapstores/TestDataFactory.java
@@ -72,6 +72,13 @@ import com.openlattice.search.requests.PersistentSearch;
 import com.openlattice.search.requests.SearchConstraints;
 import com.openlattice.search.requests.SearchDetails;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.commons.text.CharacterPredicates;
+import org.apache.commons.text.RandomStringGenerator;
+import org.apache.olingo.commons.api.edm.EdmPrimitiveTypeKind;
+import org.apache.olingo.commons.api.edm.FullQualifiedName;
+
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -85,12 +92,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
-import org.apache.commons.text.CharacterPredicates;
-import org.apache.commons.text.RandomStringGenerator;
-import org.apache.olingo.commons.api.edm.EdmPrimitiveTypeKind;
-import org.apache.olingo.commons.api.edm.FullQualifiedName;
 
 @SuppressFBWarnings( value = "SECPR", justification = "Only used for testing." )
 public final class TestDataFactory {

--- a/src/main/java/com/openlattice/mapstores/TestDataFactory.java
+++ b/src/main/java/com/openlattice/mapstores/TestDataFactory.java
@@ -81,6 +81,7 @@ import org.apache.olingo.commons.api.edm.FullQualifiedName;
 
 import java.time.OffsetDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -232,8 +233,8 @@ public final class TestDataFactory {
         UUID ptId = propertyTypes.iterator().next();
         return new AssociationType(
                 Optional.of( et ),
-                Sets.newLinkedHashSet( Arrays.asList( ptId ) ),
-                Sets.newLinkedHashSet( Arrays.asList( ptId ) ),
+                Sets.newLinkedHashSet( Collections.singletonList( ptId ) ),
+                Sets.newLinkedHashSet( Collections.singletonList( ptId ) ),
                 false );
     }
 
@@ -543,7 +544,7 @@ public final class TestDataFactory {
         return new EntityTypePropertyMetadata(
                 randomAlphanumeric( 100 ), // title
                 randomAlphanumeric( 100 ), // description
-                Sets.newLinkedHashSet( Arrays.asList( randomAlphanumeric( 5 ) ) ),
+                Sets.newLinkedHashSet( Collections.singletonList( randomAlphanumeric( 5 ) ) ),
                 r.nextBoolean()
         );
     }

--- a/src/main/java/com/openlattice/organization/OrganizationPrincipal.java
+++ b/src/main/java/com/openlattice/organization/OrganizationPrincipal.java
@@ -46,7 +46,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.openlattice.authorization.AclKey;
 import com.openlattice.authorization.SecurablePrincipal;
 
-import java.io.Serializable;
 import java.util.Optional;
 import java.util.UUID;
 

--- a/src/main/java/com/openlattice/search/requests/DataSearchResult.java
+++ b/src/main/java/com/openlattice/search/requests/DataSearchResult.java
@@ -20,7 +20,6 @@ package com.openlattice.search.requests;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.SetMultimap;
 import com.openlattice.client.serialization.SerializationConstants;
 import java.io.Serializable;
 import java.util.List;

--- a/src/main/kotlin/com/openlattice/admin/indexing/IndexAdminApi.kt
+++ b/src/main/kotlin/com/openlattice/admin/indexing/IndexAdminApi.kt
@@ -21,8 +21,6 @@
 
 package com.openlattice.admin.indexing
 
-import com.openlattice.admin.RELOAD_CACHE
-import com.openlattice.authorization.Principal
 import retrofit2.http.*
 import java.util.*
 

--- a/src/main/kotlin/com/openlattice/analysis/requests/RankingAggregation.kt
+++ b/src/main/kotlin/com/openlattice/analysis/requests/RankingAggregation.kt
@@ -23,7 +23,6 @@ package com.openlattice.analysis.requests
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.openlattice.client.serialization.SerializationConstants.NEIGHBOR_AGGREGATIONS
-import com.openlattice.client.serialization.SerializationConstants.SELF_AGGREGATIONS
 
 /**
  * Used to represent a entity neighborhood ranking aggregation request.

--- a/src/main/kotlin/com/openlattice/auditing/AuditApi.kt
+++ b/src/main/kotlin/com/openlattice/auditing/AuditApi.kt
@@ -21,10 +21,8 @@
 
 package com.openlattice.auditing
 
-import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.PUT
-import retrofit2.http.Path
 import java.util.*
 
 /**

--- a/src/main/kotlin/com/openlattice/collections/CollectionsApi.kt
+++ b/src/main/kotlin/com/openlattice/collections/CollectionsApi.kt
@@ -1,8 +1,5 @@
 package com.openlattice.collections
 
-import com.openlattice.collections.CollectionTemplateType
-import com.openlattice.collections.EntitySetCollection
-import com.openlattice.collections.EntityTypeCollection
 import com.openlattice.edm.requests.MetadataUpdate
 import retrofit2.http.*
 import java.util.*

--- a/src/main/kotlin/com/openlattice/data/Property.kt
+++ b/src/main/kotlin/com/openlattice/data/Property.kt
@@ -21,7 +21,6 @@
 
 package com.openlattice.data
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.openlattice.client.serialization.SerializationConstants
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings

--- a/src/main/kotlin/com/openlattice/directory/MaterializedViewAccount.kt
+++ b/src/main/kotlin/com/openlattice/directory/MaterializedViewAccount.kt
@@ -1,8 +1,5 @@
 package com.openlattice.directory
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.openlattice.client.serialization.SerializationConstants
-
 /**
  *
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;

--- a/src/main/kotlin/com/openlattice/entitysets/EntitySetsApi.kt
+++ b/src/main/kotlin/com/openlattice/entitysets/EntitySetsApi.kt
@@ -24,7 +24,6 @@ import com.openlattice.edm.requests.MetadataUpdate
 import com.openlattice.edm.set.EntitySetPropertyMetadata
 import com.openlattice.edm.type.PropertyType
 import retrofit2.http.*
-import java.time.OffsetDateTime
 import java.util.*
 
 

--- a/src/main/kotlin/com/openlattice/graph/GraphApi.kt
+++ b/src/main/kotlin/com/openlattice/graph/GraphApi.kt
@@ -21,13 +21,7 @@
 
 package com.openlattice.graph
 
-import com.google.common.collect.ListMultimap
-import com.google.common.collect.SetMultimap
-import com.openlattice.data.requests.NeighborEntityDetails
-import com.openlattice.graph.query.GraphQuery
-import com.openlattice.graph.query.GraphQueryState
 import retrofit2.http.Body
-import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
 import java.util.*

--- a/src/main/kotlin/com/openlattice/graph/GraphEntityConstraint.kt
+++ b/src/main/kotlin/com/openlattice/graph/GraphEntityConstraint.kt
@@ -22,10 +22,7 @@
 package com.openlattice.graph
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonIgnore
-import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.google.common.base.Preconditions.checkState
 import com.openlattice.analysis.requests.Filter
 import com.openlattice.analysis.requests.WeightedRankingAggregation
 import com.openlattice.client.serialization.SerializationConstants

--- a/src/main/kotlin/com/openlattice/graph/Neighborhood.kt
+++ b/src/main/kotlin/com/openlattice/graph/Neighborhood.kt
@@ -21,7 +21,6 @@
 
 package com.openlattice.graph
 
-import com.openlattice.data.Property
 import java.util.*
 
 /**

--- a/src/main/kotlin/com/openlattice/graph/SimpleAssociationConstraint.kt
+++ b/src/main/kotlin/com/openlattice/graph/SimpleAssociationConstraint.kt
@@ -23,7 +23,6 @@ package com.openlattice.graph
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.openlattice.client.serialization.SerializationConstants
-import java.util.*
 
 data class SimpleAssociationConstraint(
 //        @JsonProperty(SerializationConstants.ASSOCIATION_TYPE_ID) val associationTypeId: UUID,

--- a/src/main/kotlin/com/openlattice/linking/EntityLinkingFeedback.kt
+++ b/src/main/kotlin/com/openlattice/linking/EntityLinkingFeedback.kt
@@ -23,7 +23,6 @@ package com.openlattice.linking
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.openlattice.client.serialization.SerializationConstants
-import com.openlattice.data.EntityDataKey
 
 /**
  * Represents the manual feedback given between two entities, whether they are supposed to be linked or not

--- a/src/main/kotlin/com/openlattice/organization/OrganizationIntegrationAccount.kt
+++ b/src/main/kotlin/com/openlattice/organization/OrganizationIntegrationAccount.kt
@@ -21,8 +21,6 @@
 
 package com.openlattice.organization
 
-import java.util.*
-
 /**
  * Object model for returning organization integration account to the front-end.
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;


### PR DESCRIPTION
This PR:
- Fixes a bunch of mechanical warnings
- Removing unused imports
- Removing unnecessary boxing/unboxing
- Uses singletonList for one-element lists
- Uses Java classes instead of Guava for functional constructs
- Fixes compiler warnings for upgrading from Java 5 through Java 8
- Fixes several performance oriented warnings
- Removes unnecessary wrapper types
- Removes unnecessary null checking