### PR TITLE
LATTICE 2423 Fix return type and filter for columns by permission

### DIFF
--- a/src/main/kotlin/com/openlattice/organization/DatasetApi.kt
+++ b/src/main/kotlin/com/openlattice/organization/DatasetApi.kt
@@ -1,5 +1,6 @@
 package com.openlattice.organization
 
+import com.openlattice.authorization.Permission
 import com.openlattice.postgres.PostgresConnectionType
 import retrofit2.http.*
 import java.util.*
@@ -17,6 +18,7 @@ const val EXTERNAL_DATABASE = "/external-database"
 const val EXTERNAL_DATABASE_COLUMN = "/external-database-column"
 const val EXTERNAL_DATABASE_TABLE = "/external-database-table"
 const val DATA = "/data"
+const val AUTHORIZED = "/authorized"
 
 const val ID = "id"
 const val ID_PATH = "/{$ID}"
@@ -32,6 +34,8 @@ const val USER_ID = "userId"
 const val USER_ID_PATH = "/{$USER_ID}"
 const val CONNECTION_TYPE = "connectionType"
 const val CONNECTION_TYPE_PATH = "/{$CONNECTION_TYPE}"
+const val PERMISSION = "permission"
+const val PERMISSION_PATH = "/{$PERMISSION}"
 
 interface DatasetApi {
 
@@ -82,7 +86,20 @@ interface DatasetApi {
      * @param organizationId The organization's UUID
      */
     @GET(BASE + ID_PATH + EXTERNAL_DATABASE_TABLE + EXTERNAL_DATABASE_COLUMN)
-    fun getExternalDatabaseTablesWithColumns(@Path(ID) organizationId: UUID): Set<OrganizationExternalDatabaseTableColumnsPair>
+    fun getExternalDatabaseTablesWithColumnMetadata(@Path(ID) organizationId: UUID): Set<OrganizationExternalDatabaseTableColumnsPair>
+
+    /**
+     * Gets a map of all OrganizationExternalDatabaseTable objects to
+     * OrganizationExternalDatabase columns that are contained within each table
+     * based on the specified permission
+     * @param organizationId The organization's UUID
+     * @param permission The permission used to filter results
+     */
+    @GET(BASE + ID_PATH + PERMISSION_PATH + EXTERNAL_DATABASE_TABLE + EXTERNAL_DATABASE_COLUMN + AUTHORIZED)
+    fun getAuthorizedExternalDbTablesWithColumnMetadata(
+            @Path(ID) organizationId: UUID,
+            @Path(PERMISSION) permission: Permission
+    ): Set<OrganizationExternalDatabaseTableColumnsPair>
 
     /**
      * Gets an object containing an OrganizationExternalDatabaseTable
@@ -92,7 +109,7 @@ interface DatasetApi {
      * @param tableId The id of the organization's table
      */
     @GET(BASE + ID_PATH + TABLE_ID_PATH + EXTERNAL_DATABASE_TABLE + EXTERNAL_DATABASE_COLUMN)
-    fun getExternalDatabaseTableWithColumns(
+    fun getExternalDatabaseTableWithColumnMetadata(
             @Path(ID) organizationId: UUID,
             @Path(TABLE_ID) tableId: UUID
     ): OrganizationExternalDatabaseTableColumnsPair

--- a/src/main/kotlin/com/openlattice/organization/DatasetApi.kt
+++ b/src/main/kotlin/com/openlattice/organization/DatasetApi.kt
@@ -82,7 +82,7 @@ interface DatasetApi {
      * @param organizationId The organization's UUID
      */
     @GET(BASE + ID_PATH + EXTERNAL_DATABASE_TABLE + EXTERNAL_DATABASE_COLUMN)
-    fun getExternalDatabaseTablesWithColumns(@Path(ID) organizationId: UUID): Map<OrganizationExternalDatabaseTable, Set<OrganizationExternalDatabaseColumn>>
+    fun getExternalDatabaseTablesWithColumns(@Path(ID) organizationId: UUID): Set<OrganizationExternalDatabaseTableColumnsPair>
 
     /**
      * Gets an object containing an OrganizationExternalDatabaseTable


### PR DESCRIPTION
This PR
-Fixes the return type of the getTablesWithColumns api
-Renames api to clarify that returning columns returns only metadata on the columns and not any actual data
-Adds an api to filter for returning columns that a user has a provided permission on