### PR TITLE
add getter for CollectionsApi to ApiClient class

### DIFF
--- a/src/main/java/com/openlattice/client/ApiClient.java
+++ b/src/main/java/com/openlattice/client/ApiClient.java
@@ -27,6 +27,7 @@ import com.openlattice.authorization.AuthorizationsApi;
 import com.openlattice.authorization.PermissionsApi;
 import com.openlattice.client.RetrofitFactory.Environment;
 import com.openlattice.client.serialization.SerializableSupplier;
+import com.openlattice.collections.CollectionsApi;
 import com.openlattice.data.DataApi;
 import com.openlattice.data.DataIntegrationApi;
 import com.openlattice.data.S3Api;
@@ -105,6 +106,10 @@ public class ApiClient implements ApiFactoryFactory {
 
     public OrganizationsApi getOrganizationsApi() throws ExecutionException {
         return get().create( OrganizationsApi.class );
+    }
+
+    public CollectionsApi getCollectionsApi() throws ExecutionException {
+        return get().create( CollectionsApi.class );
     }
 
     public SearchApi getSearchApi() {


### PR DESCRIPTION
This is necessary for chronicle server to work with apps v2 which uses EntityTypeCollections 